### PR TITLE
Cleanup bluefin yafti firstboot stuff

### DIFF
--- a/scripts/post/cleanup-bluefin-yafti.sh
+++ b/scripts/post/cleanup-bluefin-yafti.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Tell build process to exit if there are any errors.
+set -oue pipefail
+
+# This image is based on bluefin, which adds its own yafti config. yafti also
+# adds its own, and the result is a hot mess where both try to compete for
+# first boot supremacy. Remove the bluefin one in favor of the ublue version.
+BLUEFIN_YAFTI_CONFIG="/usr/etc/yafti.yml"
+BLUEFIN_FIRSTBOOT="/usr/etc/profile.d/bluefin-firstboot.sh"
+
+rm -rf "${BLUEFIN_YAFTI_CONFIG}"
+rm -rf "${BLUEFIN_FIRSTBOOT}"


### PR DESCRIPTION
My image is based on bluefin, which has its own yafti/firstboot config that conflicts/races with the uboot one. This change removes the bluefin version in a post-build script.